### PR TITLE
Updated NEWS

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,12 +4,6 @@
 
 # CHANGES TO v0.2.12 #
 
-* Removed hard-coded type argument in `install.packages()` to allow install of binary package dependencies on Windows or OS X. (#19)
-* Changed the way a default CRAN mirror was being set in cases where there was no default mirror specified. (#19)
-* Switched to roxygen2 documentation.
-
-# CHANGES TO v0.2.11 #
-
  * Removed hard-coded `type` argument in `install.packages()` to allow install of binary package dependencies on Windows or OS X. (#19)
  * Changed the way a default CRAN mirror was being set in cases where there was no default mirror specified. (#19)
  * Switched to roxygen2 documentation.


### PR DESCRIPTION
0.2.12 was mislabelled as 0.2.11 in NEWS file (the latter not being represented on the releases page). Sorry!